### PR TITLE
fix: ignore js file when the same ts file exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
     "clean": "rimraf dist",
     "lint": "eslint src test --ext ts",
     "pretest": "npm run clean && npm run lint -- --fix && npm run prepublishOnly",
-    "test": "npm run test-local",
+    "test": "egg-bin test",
+    "posttest": "npm run clean",
     "test-local": "egg-bin test",
     "preci": "npm run clean && npm run lint && npm run prepublishOnly",
     "ci": "egg-bin cov",
+    "postci": "npm run clean",
     "prepublishOnly": "tshy && tshy-after && attw --pack"
   },
   "repository": {

--- a/src/loader/file_loader.ts
+++ b/src/loader/file_loader.ts
@@ -6,7 +6,7 @@ import globby from 'globby';
 import { isClass, isGeneratorFunction, isAsyncFunction, isPrimitive } from 'is-type-of';
 import utils, { Fun } from '../utils/index.js';
 
-const debug = debuglog('@eggjs/core:file_loader');
+const debug = debuglog('@eggjs/core/file_loader');
 
 export const FULLPATH = Symbol('EGG_LOADER_ITEM_FULLPATH');
 export const EXPORTS = Symbol('EGG_LOADER_ITEM_EXPORTS');
@@ -185,6 +185,13 @@ export class FileLoader {
       for (const filepath of filepaths) {
         const fullpath = path.join(directory, filepath);
         if (!fs.statSync(fullpath).isFile()) continue;
+        if (filepath.endsWith('.js')) {
+          const filepathTs = filepath.replace(/\.js$/, '.ts');
+          if (filepaths.includes(filepathTs)) {
+            debug('[parse] ignore %s, because %s exists', fullpath, filepathTs);
+            continue;
+          }
+        }
         // get properties
         // app/service/foo/bar.js => [ 'foo', 'bar' ]
         const properties = getProperties(filepath, this.options.caseStyle);

--- a/test/fixtures/helloworld-ts/.eslintrc
+++ b/test/fixtures/helloworld-ts/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "eslint-config-egg/typescript",
+    "eslint-config-egg/lib/rules/enforce-node-prefix"
+  ]
+}

--- a/test/fixtures/helloworld-ts/.gitignore
+++ b/test/fixtures/helloworld-ts/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/test/fixtures/helloworld-ts/app/controller/foo.js
+++ b/test/fixtures/helloworld-ts/app/controller/foo.js
@@ -1,0 +1,13 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+class FooController {
+    async render() {
+        const ctx = this.ctx;
+        ctx.status = 400;
+        ctx.body = {
+            foo: 'bar',
+        };
+    }
+}
+exports.default = FooController;
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZm9vLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiZm9vLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7O0FBQUEsNkJBQWlDO0FBRWpDLE1BQXFCLGFBQWMsU0FBUSxnQkFBVTtJQUNuRCxLQUFLLENBQUMsTUFBTTtRQUNWLE1BQU0sR0FBRyxHQUFHLElBQUksQ0FBQyxHQUFHLENBQUM7UUFDckIsR0FBRyxDQUFDLE1BQU0sR0FBRyxHQUFHLENBQUM7UUFDakIsR0FBRyxDQUFDLElBQUksR0FBRztZQUNULEdBQUcsRUFBRSxLQUFLO1NBQ1gsQ0FBQztJQUNKLENBQUM7Q0FDRjtBQVJELGdDQVFDIn0=

--- a/test/fixtures/helloworld-ts/app/controller/foo.ts
+++ b/test/fixtures/helloworld-ts/app/controller/foo.ts
@@ -1,0 +1,4 @@
+export default class FooController {
+  async render() {
+  }
+}

--- a/test/fixtures/helloworld-ts/app/router.js
+++ b/test/fixtures/helloworld-ts/app/router.js
@@ -1,0 +1,7 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = (app) => {
+    app.router.get('/', async (ctx) => {
+        ctx.body = 'Hello World';
+    });
+};

--- a/test/fixtures/helloworld-ts/app/router.ts
+++ b/test/fixtures/helloworld-ts/app/router.ts
@@ -1,0 +1,5 @@
+export default (app: any) => {
+  app.router.get('/', async (ctx: any) => {
+    ctx.body = 'Hello World';
+  });
+};

--- a/test/fixtures/helloworld-ts/config/config.default.js
+++ b/test/fixtures/helloworld-ts/config/config.default.js
@@ -1,0 +1,5 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = {
+    keys: 'my secret keys',
+};

--- a/test/fixtures/helloworld-ts/config/config.default.ts
+++ b/test/fixtures/helloworld-ts/config/config.default.ts
@@ -1,0 +1,3 @@
+export default {
+  keys: 'my secret keys',
+};

--- a/test/fixtures/helloworld-ts/package.json
+++ b/test/fixtures/helloworld-ts/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "helloworld-ts",
+  "dependencies": {
+    "egg": "beta"
+  },
+  "devDependencies": {
+    "@eggjs/bin": "7",
+    "@eggjs/mock": "6",
+    "@eggjs/tsconfig": "1",
+    "@types/mocha": "10",
+    "@types/node": "22",
+    "eslint": "8",
+    "eslint-config-egg": "14",
+    "typescript": "5"
+  },
+  "scripts": {
+    "lint": "eslint . --ext .ts",
+    "dev": "egg-bin dev",
+    "pretest": "npm run lint -- --fix",
+    "test": "egg-bin test",
+    "preci": "npm run lint",
+    "ci": "egg-bin cov",
+    "postci": "npm run prepublishOnly && npm run clean",
+    "clean": "tsc -b --clean",
+    "prepublishOnly": "npm run clean && tsc"
+  },
+  "private": true,
+  "repository": "git@github.com:eggjs/examples.git"
+}

--- a/test/fixtures/helloworld-ts/test/index.test.ts
+++ b/test/fixtures/helloworld-ts/test/index.test.ts
@@ -1,0 +1,19 @@
+import { app } from '@eggjs/mock/bootstrap';
+
+describe('example helloworld test', () => {
+  it('should GET / 200', () => {
+    return app.httpRequest()
+      .get('/')
+      .expect(200)
+      .expect('Hello World');
+  });
+
+  it('should GET /foo', async () => {
+    await app.httpRequest()
+      .get('/foo')
+      .expect(400)
+      .expect({
+        foo: 'bar',
+      });
+  });
+});

--- a/test/fixtures/helloworld-ts/tsconfig.json
+++ b/test/fixtures/helloworld-ts/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@eggjs/tsconfig",
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitAny": true,
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": false
+  },
+  "exclude": [
+    "test"
+  ]
+}

--- a/test/support-typescript.test.ts
+++ b/test/support-typescript.test.ts
@@ -1,0 +1,22 @@
+import { strict as assert } from 'node:assert';
+import request from 'supertest';
+import { getFilepath } from './helper.js';
+import { Application } from './fixtures/egg-esm/index.js';
+
+describe('test/support-typescript.test.ts', () => {
+  let app: Application;
+  before(async () => {
+    app = new Application({
+      baseDir: getFilepath('helloworld-ts'),
+      type: 'application',
+    });
+    await app.loader.loadAll();
+  });
+
+  it('should ignore *.js when *.ts same file exists', async () => {
+    const res = await request(app.callback())
+      .get('/');
+    assert.equal(res.status, 200);
+    assert.equal(res.text, 'Hello World');
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added TypeScript support for Egg.js framework
	- Introduced a new TypeScript example project with basic routing and configuration

- **Bug Fixes**
	- Improved file loading logic to prevent conflicts between `.js` and `.ts` files

- **Chores**
	- Updated package scripts for testing and continuous integration
	- Added ESLint and TypeScript configuration files
	- Updated dependencies to support TypeScript development

- **Tests**
	- Added comprehensive test suite for TypeScript project
	- Implemented test cases for route handling and application behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->