### PR TITLE
fix: don't set template Context on BaseContextClass

### DIFF
--- a/src/base_context_class.ts
+++ b/src/base_context_class.ts
@@ -5,16 +5,16 @@ import type { EggCore, Context } from './egg.js';
  * it's instantiated in context level,
  * {@link Helper}, {@link Service} is extending it.
  */
-export class BaseContextClass<T extends Context = Context> {
-  ctx: T;
+export class BaseContextClass {
+  ctx: Context;
   app: EggCore;
   config: Record<string, any>;
-  service: BaseContextClass<T>;
+  service: BaseContextClass;
 
   /**
    * @since 1.0.0
    */
-  constructor(ctx: T) {
+  constructor(ctx: Context) {
     /**
      * @member {Context} BaseContextClass#ctx
      * @since 1.0.0
@@ -34,6 +34,6 @@ export class BaseContextClass<T extends Context = Context> {
      * @member {Service} BaseContextClass#service
      * @since 1.0.0
      */
-    this.service = ctx.service as BaseContextClass<T>;
+    this.service = ctx.service;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified `BaseContextClass` by removing generic type parameters
	- Standardized context type handling within the class
	- Updated class, property, and constructor type definitions to use a consistent `Context` type

<!-- end of auto-generated comment: release notes by coderabbit.ai -->