### PR TITLE
fix: support load plugin from typescript dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@eggjs/koa": "^2.20.6",
     "@eggjs/router": "^3.0.5",
-    "@eggjs/utils": "^4.1.5",
+    "@eggjs/utils": "^4.2.4",
     "egg-logger": "^3.5.0",
     "egg-path-matching": "^2.0.0",
     "extend2": "^4.0.0",

--- a/test/fixtures/plugin-ts-src/config/config.js
+++ b/test/fixtures/plugin-ts-src/config/config.js
@@ -1,0 +1,3 @@
+exports.plugin = 'override plugin';
+
+exports.middleware = [];

--- a/test/fixtures/plugin-ts-src/config/plugin.js
+++ b/test/fixtures/plugin-ts-src/config/plugin.js
@@ -1,0 +1,7 @@
+const path = require('path');
+
+module.exports = {
+  agg: {
+    path: path.join(__dirname, '../plugins/g'),
+  },
+};

--- a/test/fixtures/plugin-ts-src/package.json
+++ b/test/fixtures/plugin-ts-src/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "plugin-ts-src"
+}

--- a/test/fixtures/plugin-ts-src/plugins/g/package.json
+++ b/test/fixtures/plugin-ts-src/plugins/g/package.json
@@ -1,0 +1,11 @@
+{
+  "eggPlugin": {
+    "name": "g",
+    "exports": {
+      "require": "./dist/commonjs",
+      "import": "./dist/esm",
+      "typescript": "./src"
+    }
+  },
+  "version": "1.0.0"
+}

--- a/test/fixtures/plugin-ts-src/plugins/g/src/index.ts
+++ b/test/fixtures/plugin-ts-src/plugins/g/src/index.ts
@@ -1,0 +1,1 @@
+export const foo = 'bar';

--- a/test/loader/mixin/load_plugin.test.ts
+++ b/test/loader/mixin/load_plugin.test.ts
@@ -222,6 +222,13 @@ describe('test/loader/mixin/load_plugin.test.ts', () => {
     assert(!message);
   });
 
+  it('should load plugin when eggPlugin.exports.typescript = "./src" exists', async () => {
+    app = createApp('plugin-ts-src');
+    const loader = app.loader;
+    await loader.loadPlugin();
+    assert.match(loader.allPlugins.agg.path!, /src$/);
+  });
+
   it('should loadConfig plugins with custom plugins config', async () => {
     const baseDir = getFilepath('plugin');
     const plugins = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Dependencies**
  - Updated `@eggjs/utils` from version 4.1.5 to 4.2.4

- **Improvements**
  - Enhanced plugin loading mechanism for TypeScript projects
  - Improved error handling and logging for TypeScript configuration files

- **Testing**
  - Added new test case for TypeScript plugin loading scenarios

These updates improve the framework's compatibility and robustness when working with TypeScript plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->