### PR TITLE
fix: loadFile ignore ts extend on readFileSync

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -78,7 +78,7 @@ export default {
     try {
       // if not js module, just return content buffer
       const extname = path.extname(filepath);
-      if (extname && !extensionNames.includes(extname)) {
+      if (extname && !extensionNames.includes(extname) && extname !== '.ts') {
         return fs.readFileSync(filepath);
       }
       const obj = await importModule(filepath, { importDefaultOnly: true });


### PR DESCRIPTION
https://github.com/eggjs/tegg/pull/283

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the file loading functionality to properly differentiate TypeScript files from other file types. This modification prevents unintended processing behavior for TypeScript content, ensuring more reliable file operations and enhancing overall stability in handling various file formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->